### PR TITLE
Update the routing cfg

### DIFF
--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -569,6 +569,8 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         """Wrapper function to generate all the routing info for the network,
         for a specific routing algorithm."""
         self.routing.num_endpoints = len(self.graph.get_ni_nodes())
+        self.routing.num_cols = self.routers[0].array[0]
+        self.routing.num_nums = self.routers[0].array[1]
         if self.routing.num_endpoints == 0:
             raise ValueError(
                 "No endpoints found in the network. Use the `only_pkg` flag for package generation."


### PR DESCRIPTION
This PR updates the NumSamRules calculation in `floogen/model/routing.py` line 584

The num_rows is not correctly setted in the previous version.